### PR TITLE
FHE precompile runtime access via FheApp struct

### DIFF
--- a/src/c_fhe.rs
+++ b/src/c_fhe.rs
@@ -20,7 +20,7 @@ macro_rules! create_c_precompile_function {
             /// * `output` - A double pointer where the result will be stored on success.
             /// * `output_length` - The length of the output data on success.
             #[no_mangle]
-            pub extern "C" fn [< c_fhe_ $name >] (
+            pub unsafe extern "C" fn [< c_fhe_ $name >] (
                 bytes: *const u8,
                 bytes_length: libc::size_t,
                 output: *mut *mut u8,

--- a/src/fhe.rs
+++ b/src/fhe.rs
@@ -6,7 +6,8 @@ use bincode::serialize;
 use sunscreen::{
     fhe_program,
     types::{bfv::Signed, Cipher},
-    Application, Ciphertext, Compiler, FheProgramInput, Params, PublicKey, Runtime, RuntimeError,
+    Application, Ciphertext, Compiler, FheProgramInput, Params, PrivateKey, PublicKey, Runtime,
+    RuntimeError,
 };
 
 /// Expects input to be packed with the
@@ -40,6 +41,7 @@ pub struct FheApp {
 }
 
 impl FheApp {
+    /// Generate the FHE precompile functions for a specific set of parameters.
     pub fn from_params(params: &Params) -> Self {
         let params = params.clone();
         let application = Compiler::new()
@@ -57,6 +59,25 @@ impl FheApp {
             application,
             runtime,
         }
+    }
+
+    /// Generate keys for an FHE application without the galois keys.
+    pub fn generate_keys(&self) -> Result<(PublicKey, PrivateKey), RuntimeError> {
+        let (public_key, private_key) = self.runtime.generate_keys()?;
+
+        Ok((public_key, private_key))
+    }
+
+    /// Generate keys for an FHE application without the galois keys.
+    pub fn generate_keys_without_galois(&self) -> Result<(PublicKey, PrivateKey), RuntimeError> {
+        let (public_key, private_key) = self.generate_keys()?;
+
+        let public_key = PublicKey {
+            galois_key: None,
+            ..public_key
+        };
+
+        Ok((public_key, private_key))
     }
 
     fn run(
@@ -123,6 +144,10 @@ impl FheApp {
 
         Ok(serialize(&zero).unwrap())
     }
+
+    pub fn runtime(&self) -> &Runtime {
+        &self.runtime
+    }
 }
 
 /// Addition
@@ -162,30 +187,30 @@ mod tests {
 
     use super::*;
     use crate::pack::{pack_binary_operation, pack_binary_plain_operation, pack_nullary_operation};
-    use crate::testnet::one::{generate_keys, FHE, RUNTIME};
+    use crate::testnet::one::FHE;
 
     #[test]
     fn fhe_add_works() -> Result<(), RuntimeError> {
-        let (public_key, private_key) = generate_keys().unwrap();
+        let (public_key, private_key) = FHE.generate_keys_without_galois().unwrap();
 
-        let a = RUNTIME.encrypt(Signed::from(16), &public_key)?;
-        let b = RUNTIME.encrypt(Signed::from(4), &public_key)?;
+        let a = FHE.runtime.encrypt(Signed::from(16), &public_key)?;
+        let b = FHE.runtime.encrypt(Signed::from(4), &public_key)?;
 
         let result = FHE.run(add, a, b, public_key)?;
-        let c: Signed = RUNTIME.decrypt(&result, &private_key)?;
+        let c: Signed = FHE.runtime.decrypt(&result, &private_key)?;
         assert_eq!(<Signed as Into<i64>>::into(c), 20_i64);
         Ok(())
     }
 
     #[test]
     fn fhe_multiply_works() -> Result<(), RuntimeError> {
-        let (public_key, private_key) = generate_keys().unwrap();
+        let (public_key, private_key) = FHE.generate_keys_without_galois().unwrap();
 
-        let a = RUNTIME.encrypt(Signed::from(16), &public_key)?;
-        let b = RUNTIME.encrypt(Signed::from(4), &public_key)?;
+        let a = FHE.runtime.encrypt(Signed::from(16), &public_key)?;
+        let b = FHE.runtime.encrypt(Signed::from(4), &public_key)?;
 
         let result = FHE.run(multiply, a, b, public_key)?;
-        let c: Signed = RUNTIME.decrypt(&result, &private_key)?;
+        let c: Signed = FHE.runtime.decrypt(&result, &private_key)?;
         assert_eq!(<Signed as Into<i64>>::into(c), 64_i64);
         Ok(())
     }
@@ -222,7 +247,7 @@ mod tests {
 
     #[test]
     fn precompile_encrypt_zero_works() -> Result<(), RuntimeError> {
-        let (public_key, private_key) = generate_keys().unwrap();
+        let (public_key, private_key) = FHE.generate_keys_without_galois().unwrap();
 
         // Encode public_key
         let public_key_enc = pack_nullary_operation(&public_key);
@@ -232,7 +257,7 @@ mod tests {
         // decode it
         let c_encrypted = deserialize(&output).unwrap();
         // decrypt it
-        let c: Signed = RUNTIME.decrypt(&c_encrypted, &private_key)?;
+        let c: Signed = FHE.runtime.decrypt(&c_encrypted, &private_key)?;
 
         assert_eq!(0, <Signed as Into<i64>>::into(c));
         Ok(())
@@ -247,11 +272,11 @@ mod tests {
     where
         F: Fn(&[u8]) -> PrecompileResult,
     {
-        let (public_key, private_key) = generate_keys().unwrap();
+        let (public_key, private_key) = FHE.generate_keys_without_galois().unwrap();
 
         // Encrypt values
-        let a_encrypted = RUNTIME.encrypt(Signed::from(a), &public_key)?;
-        let b_encrypted = RUNTIME.encrypt(Signed::from(b), &public_key)?;
+        let a_encrypted = FHE.runtime.encrypt(Signed::from(a), &public_key)?;
+        let b_encrypted = FHE.runtime.encrypt(Signed::from(b), &public_key)?;
 
         let input = pack_binary_operation(&public_key, &a_encrypted, &b_encrypted);
 
@@ -262,7 +287,7 @@ mod tests {
         let c_encrypted = deserialize(&output).unwrap();
 
         // decrypt it
-        let c: Signed = RUNTIME.decrypt(&c_encrypted, &private_key)?;
+        let c: Signed = FHE.runtime.decrypt(&c_encrypted, &private_key)?;
 
         assert_eq!(expected, <Signed as Into<i64>>::into(c));
         Ok(())
@@ -277,10 +302,10 @@ mod tests {
     where
         F: Fn(&[u8]) -> PrecompileResult,
     {
-        let (public_key, private_key) = generate_keys().unwrap();
+        let (public_key, private_key) = FHE.generate_keys_without_galois().unwrap();
 
         // Encrypt a
-        let a_encrypted = RUNTIME.encrypt(Signed::from(a), &public_key)?;
+        let a_encrypted = FHE.runtime.encrypt(Signed::from(a), &public_key)?;
 
         let input = pack_binary_plain_operation(&public_key, &a_encrypted, &Signed::from(b));
 
@@ -291,7 +316,7 @@ mod tests {
         let c_encrypted = deserialize(&output).unwrap();
 
         // decrypt it
-        let c: Signed = RUNTIME.decrypt(&c_encrypted, &private_key)?;
+        let c: Signed = FHE.runtime.decrypt(&c_encrypted, &private_key)?;
 
         assert_eq!(expected, <Signed as Into<i64>>::into(c));
         Ok(())

--- a/src/pack.rs
+++ b/src/pack.rs
@@ -164,7 +164,7 @@ mod tests {
 
     use super::*;
     use crate::pack::{pack_binary_operation, pack_binary_plain_operation, pack_nullary_operation};
-    use crate::testnet::one::{generate_keys, RUNTIME};
+    use crate::testnet::one::FHE;
 
     fn assert_serialized_eq<T>(a: &T, b: &T)
     where
@@ -175,10 +175,13 @@ mod tests {
 
     #[test]
     fn unpack_pack_binary_is_id() -> Result<(), FheError> {
-        let (public_key, _) = generate_keys().unwrap();
+        let (public_key, _) = FHE.generate_keys_without_galois().unwrap();
 
-        let a = RUNTIME.encrypt(Signed::from(16), &public_key).unwrap();
-        let b = RUNTIME.encrypt(Signed::from(4), &public_key).unwrap();
+        let a = FHE
+            .runtime()
+            .encrypt(Signed::from(16), &public_key)
+            .unwrap();
+        let b = FHE.runtime().encrypt(Signed::from(4), &public_key).unwrap();
 
         let input = pack_binary_operation(&public_key, &a, &b);
         let (public_key_reconstituted, a_reconstituted, b_reconstituted) =
@@ -192,10 +195,13 @@ mod tests {
 
     #[test]
     fn pack_unpack_binary_is_id() -> Result<(), FheError> {
-        let (public_key, _) = generate_keys().unwrap();
+        let (public_key, _) = FHE.generate_keys_without_galois().unwrap();
 
-        let a = RUNTIME.encrypt(Signed::from(16), &public_key).unwrap();
-        let b = RUNTIME.encrypt(Signed::from(4), &public_key).unwrap();
+        let a = FHE
+            .runtime()
+            .encrypt(Signed::from(16), &public_key)
+            .unwrap();
+        let b = FHE.runtime().encrypt(Signed::from(4), &public_key).unwrap();
 
         let input = pack_binary_operation(&public_key, &a, &b);
 
@@ -214,9 +220,12 @@ mod tests {
 
     #[test]
     fn unpack_pack_binary_plain_is_id() -> Result<(), FheError> {
-        let (public_key, _) = generate_keys().unwrap();
+        let (public_key, _) = FHE.generate_keys_without_galois().unwrap();
 
-        let a = RUNTIME.encrypt(Signed::from(16), &public_key).unwrap();
+        let a = FHE
+            .runtime()
+            .encrypt(Signed::from(16), &public_key)
+            .unwrap();
         let b = Signed::from(4);
 
         let input = pack_binary_plain_operation(&public_key, &a, &b);
@@ -231,9 +240,12 @@ mod tests {
 
     #[test]
     fn pack_unpack_binary_plain_is_id() -> Result<(), FheError> {
-        let (public_key, _) = generate_keys().unwrap();
+        let (public_key, _) = FHE.generate_keys_without_galois().unwrap();
 
-        let a = RUNTIME.encrypt(Signed::from(16), &public_key).unwrap();
+        let a = FHE
+            .runtime()
+            .encrypt(Signed::from(16), &public_key)
+            .unwrap();
         let b = Signed::from(4);
 
         let input = pack_binary_plain_operation(&public_key, &a, &b);
@@ -253,7 +265,7 @@ mod tests {
 
     #[test]
     fn unpack_pack_nullary_is_id() -> Result<(), FheError> {
-        let (public_key, _) = generate_keys().unwrap();
+        let (public_key, _) = FHE.generate_keys_without_galois().unwrap();
 
         let input = pack_nullary_operation(&public_key);
         let public_key_reconstituted = unpack_nullary_operation(&input)?;
@@ -264,7 +276,7 @@ mod tests {
 
     #[test]
     fn pack_unpack_nullary_is_id() -> Result<(), FheError> {
-        let (public_key, _) = generate_keys().unwrap();
+        let (public_key, _) = FHE.generate_keys_without_galois().unwrap();
 
         let input = pack_nullary_operation(&public_key);
         let public_key_reconstituted = unpack_nullary_operation(&input)?;

--- a/src/testnet.rs
+++ b/src/testnet.rs
@@ -1,36 +1,18 @@
 /// Parameters related to the first testnet
 pub mod one {
     use once_cell::sync::Lazy;
-    use sunscreen::{Params, PrivateKey, PublicKey, Runtime, SchemeType};
+    use sunscreen::{Params, SchemeType};
 
     use crate::fhe::FheApp;
 
     /// Key generation and runtime parameters for the first testnet.
-    pub static PARAMS: Lazy<Params> = Lazy::new(|| Params {
+    static PARAMS: Lazy<Params> = Lazy::new(|| Params {
         lattice_dimension: 4096,
         coeff_modulus: vec![0xffffee001, 0xffffc4001, 0x1ffffe0001],
         plain_modulus: 4_096,
         scheme_type: SchemeType::Bfv,
         security_level: sunscreen::SecurityLevel::TC128,
     });
-
-    /// [`sunscreen::Runtime`] for the first testnet
-    pub static RUNTIME: Lazy<Runtime> = Lazy::new(|| Runtime::new(&PARAMS).unwrap());
-
-    /// Generate public and private keys that work with the first testnet.
-    // Note clippy allowance can be removed when upgrading sunscreen
-    #[allow(clippy::result_large_err)]
-    pub fn generate_keys() -> Result<(PublicKey, PrivateKey), sunscreen::Error> {
-        let (public_key, private_key) = RUNTIME.generate_keys()?;
-        Ok((
-            PublicKey {
-                // unnecessary galois portion (cuts keys from ~13MB to 1.3MB).
-                galois_key: None,
-                ..public_key
-            },
-            private_key,
-        ))
-    }
 
     /// The FHE precompile operations available in the first testnet.
     pub static FHE: Lazy<FheApp> = Lazy::new(|| FheApp::from_params(&PARAMS));


### PR DESCRIPTION
Instead of defining the runtime twice, we reference the one in the FheApp struct. The idea is that it is less likely for the user to use a runtime not associated with the FheApp instance.

Also marks the C functions as unsafe since they deference a pointer.