### PR TITLE
FHE precompile runtime access via FheApp struct

### DIFF
--- a/src/pack.rs
+++ b/src/pack.rs
@@ -164,7 +164,7 @@ mod tests {
 
     use super::*;
     use crate::pack::{pack_binary_operation, pack_binary_plain_operation, pack_nullary_operation};
-    use crate::testnet::one::{generate_keys, RUNTIME};
+    use crate::testnet::one::FHE;
 
     fn assert_serialized_eq<T>(a: &T, b: &T)
     where
@@ -175,10 +175,13 @@ mod tests {
 
     #[test]
     fn unpack_pack_binary_is_id() -> Result<(), FheError> {
-        let (public_key, _) = generate_keys().unwrap();
+        let (public_key, _) = FHE.generate_keys_without_galois().unwrap();
 
-        let a = RUNTIME.encrypt(Signed::from(16), &public_key).unwrap();
-        let b = RUNTIME.encrypt(Signed::from(4), &public_key).unwrap();
+        let a = FHE
+            .runtime()
+            .encrypt(Signed::from(16), &public_key)
+            .unwrap();
+        let b = FHE.runtime().encrypt(Signed::from(4), &public_key).unwrap();
 
         let input = pack_binary_operation(&public_key, &a, &b);
         let (public_key_reconstituted, a_reconstituted, b_reconstituted) =
@@ -192,10 +195,13 @@ mod tests {
 
     #[test]
     fn pack_unpack_binary_is_id() -> Result<(), FheError> {
-        let (public_key, _) = generate_keys().unwrap();
+        let (public_key, _) = FHE.generate_keys_without_galois().unwrap();
 
-        let a = RUNTIME.encrypt(Signed::from(16), &public_key).unwrap();
-        let b = RUNTIME.encrypt(Signed::from(4), &public_key).unwrap();
+        let a = FHE
+            .runtime()
+            .encrypt(Signed::from(16), &public_key)
+            .unwrap();
+        let b = FHE.runtime().encrypt(Signed::from(4), &public_key).unwrap();
 
         let input = pack_binary_operation(&public_key, &a, &b);
 
@@ -214,9 +220,12 @@ mod tests {
 
     #[test]
     fn unpack_pack_binary_plain_is_id() -> Result<(), FheError> {
-        let (public_key, _) = generate_keys().unwrap();
+        let (public_key, _) = FHE.generate_keys_without_galois().unwrap();
 
-        let a = RUNTIME.encrypt(Signed::from(16), &public_key).unwrap();
+        let a = FHE
+            .runtime()
+            .encrypt(Signed::from(16), &public_key)
+            .unwrap();
         let b = Signed::from(4);
 
         let input = pack_binary_plain_operation(&public_key, &a, &b);
@@ -231,9 +240,12 @@ mod tests {
 
     #[test]
     fn pack_unpack_binary_plain_is_id() -> Result<(), FheError> {
-        let (public_key, _) = generate_keys().unwrap();
+        let (public_key, _) = FHE.generate_keys_without_galois().unwrap();
 
-        let a = RUNTIME.encrypt(Signed::from(16), &public_key).unwrap();
+        let a = FHE
+            .runtime()
+            .encrypt(Signed::from(16), &public_key)
+            .unwrap();
         let b = Signed::from(4);
 
         let input = pack_binary_plain_operation(&public_key, &a, &b);
@@ -253,7 +265,7 @@ mod tests {
 
     #[test]
     fn unpack_pack_nullary_is_id() -> Result<(), FheError> {
-        let (public_key, _) = generate_keys().unwrap();
+        let (public_key, _) = FHE.generate_keys_without_galois().unwrap();
 
         let input = pack_nullary_operation(&public_key);
         let public_key_reconstituted = unpack_nullary_operation(&input)?;
@@ -264,7 +276,7 @@ mod tests {
 
     #[test]
     fn pack_unpack_nullary_is_id() -> Result<(), FheError> {
-        let (public_key, _) = generate_keys().unwrap();
+        let (public_key, _) = FHE.generate_keys_without_galois().unwrap();
 
         let input = pack_nullary_operation(&public_key);
         let public_key_reconstituted = unpack_nullary_operation(&input)?;

--- a/src/testnet.rs
+++ b/src/testnet.rs
@@ -1,34 +1,17 @@
 /// Parameters related to the first testnet
 pub mod one {
-    use once_cell::sync::Lazy;
-    use sunscreen::{FheRuntime, Params, PrivateKey, PublicKey, Runtime, SchemeType};
-
     use crate::fhe::FheApp;
+    use once_cell::sync::Lazy;
+    use sunscreen::{Params, SchemeType};
 
     /// Key generation and runtime parameters for the first testnet.
-    pub static PARAMS: Lazy<Params> = Lazy::new(|| Params {
+    static PARAMS: Lazy<Params> = Lazy::new(|| Params {
         lattice_dimension: 4096,
         coeff_modulus: vec![0xffffee001, 0xffffc4001, 0x1ffffe0001],
         plain_modulus: 4_096,
         scheme_type: SchemeType::Bfv,
         security_level: sunscreen::SecurityLevel::TC128,
     });
-
-    /// [`sunscreen::FheRuntime`] for the first testnet
-    pub static RUNTIME: Lazy<FheRuntime> = Lazy::new(|| Runtime::new_fhe(&PARAMS).unwrap());
-
-    /// Generate public and private keys that work with the first testnet.
-    pub fn generate_keys() -> Result<(PublicKey, PrivateKey), sunscreen::Error> {
-        let (public_key, private_key) = RUNTIME.generate_keys()?;
-        Ok((
-            PublicKey {
-                // unnecessary galois portion (cuts keys from ~13MB to 1.3MB).
-                galois_key: None,
-                ..public_key
-            },
-            private_key,
-        ))
-    }
 
     /// The FHE precompile operations available in the first testnet.
     pub static FHE: Lazy<FheApp> = Lazy::new(|| FheApp::from_params(&PARAMS));


### PR DESCRIPTION
Instead of defining the runtime twice, we reference the one in the FheApp struct. The idea is that it is less likely for the user to use a runtime not associated with the FheApp instance.

Brings back to life #6 since we ended up being able to have Send + Sync Applications.